### PR TITLE
建议在用法示例中加入联网参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ API 总是提供原生的结果，如果不希望异常退出，或需要更友�
 
 ```sh
 $ python cli.py auth4 checklogin
-$ cat password.txt | python cli.py auth4 login -u username
+$ cat password.txt | python cli.py auth4 login -n -u username
 $ python cli.py net checklogin
 ```
 


### PR DESCRIPTION
不然容易让刚开始配置的人感到困惑...
另外 `-n` 参数的解释改为 `access to the Internet` 是否更佳合适？